### PR TITLE
Fix variable interpolation

### DIFF
--- a/src/MacroableModels.php
+++ b/src/MacroableModels.php
@@ -78,7 +78,7 @@ class MacroableModels
             $class = get_class($this->getModel());
 
             if (!isset($models[$class])) {
-                throw new \BadMethodCallException("Call to undefined method ${class}::${name}()");
+                throw new \BadMethodCallException(sprintf('Call to undefined method %s::%s()', $class, $name));
             }
 
             $closure = \Closure::bind($models[$class], $this->getModel());


### PR DESCRIPTION
Hello,
On a project running php 8.2, I have this error:

```
Using ${var} in strings is deprecated, use {$var} instead in vendor/javoscript/laravel-macroable-models/src/MacroableModels.php
```

I fixed it using the code in the PR, to be compatible with older versions of php.