### PR TITLE
Using scoped instead of singleton

### DIFF
--- a/src/MacroableModelsServiceProvider.php
+++ b/src/MacroableModelsServiceProvider.php
@@ -8,7 +8,7 @@ class MacroableModelsServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $this->app->singleton('macroable-models', function () {
+        $this->app->scoped('macroable-models', function () {
             return new MacroableModels();
         });
     }


### PR DESCRIPTION
The `scoped` method binds a class or interface into the container that should only be resolved one time within a given Laravel request / job lifecycle. While this method is similar to the `singleton` method, instances registered using the `scoped` method will be flushed whenever the Laravel application starts a new "lifecycle", such as when a [Laravel Octane](https://laravel.com/docs/11.x/octane) worker processes a new request or when a Laravel [queue worker](https://laravel.com/docs/11.x/queues) processes a new job